### PR TITLE
Three fixes here: Fixed final animation value for keyframe animations, f...

### DIFF
--- a/MTAnimation.xcodeproj/project.pbxproj
+++ b/MTAnimation.xcodeproj/project.pbxproj
@@ -7,10 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		875B42E519EE632B00005F77 /* MTMatrixInterpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 875B42E419EE632B00005F77 /* MTMatrixInterpolation.m */; };
+		875B42E619EE633000005F77 /* MTMatrixInterpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 875B42E419EE632B00005F77 /* MTMatrixInterpolation.m */; };
 		C21CB4EA175164C00082CB97 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2AF91451729F564001D44D5 /* Foundation.framework */; };
 		C21CB4F5175164E10082CB97 /* UIView+MTAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = C2AF91831729F584001D44D5 /* UIView+MTAnimation.m */; };
 		C21CB4F6175164E60082CB97 /* MTTimingFunctions.c in Sources */ = {isa = PBXBuildFile; fileRef = C2AF91851729F584001D44D5 /* MTTimingFunctions.c */; };
-		C21CB4F7175164EA0082CB97 /* MTMatrixInterpolation.c in Sources */ = {isa = PBXBuildFile; fileRef = C2B71A9717341C9B00E508B8 /* MTMatrixInterpolation.c */; };
 		C22CC0D4172A009700EB3CB3 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C22CC0D3172A009700EB3CB3 /* QuartzCore.framework */; };
 		C241F04B1751D6BA00B9AAA5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2AF91431729F564001D44D5 /* UIKit.framework */; };
 		C241F04C1751D6CA00B9AAA5 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C22CC0D3172A009700EB3CB3 /* QuartzCore.framework */; };
@@ -35,7 +36,6 @@
 		C2AF91861729F584001D44D5 /* UIView+MTAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = C2AF91831729F584001D44D5 /* UIView+MTAnimation.m */; };
 		C2AF91871729F584001D44D5 /* MTTimingFunctions.c in Sources */ = {isa = PBXBuildFile; fileRef = C2AF91851729F584001D44D5 /* MTTimingFunctions.c */; };
 		C2AF91891729F5A1001D44D5 /* logo.png in Resources */ = {isa = PBXBuildFile; fileRef = C2AF91881729F5A1001D44D5 /* logo.png */; };
-		C2B71A9817341C9B00E508B8 /* MTMatrixInterpolation.c in Sources */ = {isa = PBXBuildFile; fileRef = C2B71A9717341C9B00E508B8 /* MTMatrixInterpolation.c */; };
 		KIYDQKWBMRKIEYEVRWSLKUDQ /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = HYXIFWTDXJPPRRMDCEPMDTJH /* libz.dylib */; };
 /* End PBXBuildFile section */
 
@@ -62,6 +62,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		875B42E419EE632B00005F77 /* MTMatrixInterpolation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTMatrixInterpolation.m; sourceTree = "<group>"; };
 		C21CB4E9175164C00082CB97 /* libMTAnimation.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMTAnimation.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		C22CC0D3172A009700EB3CB3 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		C27D915B1753CAC200C622DA /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/ApplicationServices.framework; sourceTree = DEVELOPER_DIR; };
@@ -96,7 +97,6 @@
 		C2AF91841729F584001D44D5 /* MTTimingFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTTimingFunctions.h; sourceTree = "<group>"; };
 		C2AF91851729F584001D44D5 /* MTTimingFunctions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = MTTimingFunctions.c; sourceTree = "<group>"; };
 		C2AF91881729F5A1001D44D5 /* logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = logo.png; sourceTree = "<group>"; };
-		C2B71A9717341C9B00E508B8 /* MTMatrixInterpolation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = MTMatrixInterpolation.c; sourceTree = "<group>"; };
 		C2B71A9917341CB100E508B8 /* MTMatrixInterpolation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTMatrixInterpolation.h; sourceTree = "<group>"; };
 		HYXIFWTDXJPPRRMDCEPMDTJH /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -229,7 +229,7 @@
 				C2AF91841729F584001D44D5 /* MTTimingFunctions.h */,
 				C2AF91851729F584001D44D5 /* MTTimingFunctions.c */,
 				C2B71A9917341CB100E508B8 /* MTMatrixInterpolation.h */,
-				C2B71A9717341C9B00E508B8 /* MTMatrixInterpolation.c */,
+				875B42E419EE632B00005F77 /* MTMatrixInterpolation.m */,
 				C2A2AC6C1734243900085235 /* MTAnimationTypes.h */,
 			);
 			name = MTAnimation;
@@ -368,9 +368,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				875B42E619EE633000005F77 /* MTMatrixInterpolation.m in Sources */,
 				C21CB4F5175164E10082CB97 /* UIView+MTAnimation.m in Sources */,
 				C21CB4F6175164E60082CB97 /* MTTimingFunctions.c in Sources */,
-				C21CB4F7175164EA0082CB97 /* MTMatrixInterpolation.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -378,12 +378,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				875B42E519EE632B00005F77 /* MTMatrixInterpolation.m in Sources */,
 				C2AF91501729F564001D44D5 /* main.m in Sources */,
 				C2AF91541729F564001D44D5 /* MTAppDelegate.m in Sources */,
 				C2AF91631729F564001D44D5 /* MTViewController.m in Sources */,
 				C2AF91861729F584001D44D5 /* UIView+MTAnimation.m in Sources */,
 				C2AF91871729F584001D44D5 /* MTTimingFunctions.c in Sources */,
-				C2B71A9817341C9B00E508B8 /* MTMatrixInterpolation.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MTAnimation/MTMatrixInterpolation.h
+++ b/MTAnimation/MTMatrixInterpolation.h
@@ -1,13 +1,16 @@
-//
-//  MTMatrixInterpolation.h
-//  MTAnimation
-//
-//  Created by Adam Kirk on 5/3/13.
-//  Copyright (c) 2013 Mysterious Trousers. All rights reserved.
-//
-//  Extracts taken from http://svn.gna.org/svn/gnustep/libs/quartzcore/trunk/Source/CAAnimation.m
+#ifndef MT_MATRIXINTERPOLAITON_H
+#define MT_MATRIXINTERPOLAITON_H
 
-#include <QuartzCore/QuartzCore.h>
+#import <QuartzCore/QuartzCore.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 CATransform3D interpolatedMatrixFromMatrix(CATransform3D fromTf, CATransform3D toTf, CGFloat fraction);
 
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/MTAnimation/MTMatrixInterpolation.m
+++ b/MTAnimation/MTMatrixInterpolation.m
@@ -8,8 +8,8 @@
 //  Extracts taken from http://svn.gna.org/svn/gnustep/libs/quartzcore/trunk/Source/CAAnimation.m
 
 
-
-#include "MTMatrixInterpolation.h"
+#import <QuartzCore/QuartzCore.h>
+#import "MTMatrixInterpolation.h"
 
 
 #define GSQC_POW2(x) ((x)*(x))
@@ -22,16 +22,15 @@ typedef struct _GSQuartzCoreQuaternion
 
 static CGFloat linearInterpolation(CGFloat from, CGFloat to, CGFloat fraction)
 {
-    return from + (to-from)*fraction;
+    return from + (to - from) * fraction;
 }
 
 static CATransform3D transpose(CATransform3D m)
 {
     CATransform3D r;
-    CGFloat *mF = (CGFloat *)&m;
-    CGFloat *rF = (CGFloat *)&r;
-    for(int i = 0; i < 16; i++)
-    {
+    CGFloat *mF = (CGFloat *) &m;
+    CGFloat *rF = (CGFloat *) &r;
+    for (int i = 0; i < 16; i ++) {
         int col = i % 4;
         int row = i / 4;
         int j = col * 4 + row;
@@ -48,21 +47,21 @@ static CATransform3D transpose(CATransform3D m)
 static CATransform3D quaternionToMatrix(GSQuartzCoreQuaternion q)
 {
     CATransform3D m;
-    CGFloat x=q.x, y=q.y, z=q.z, w=q.w;
+    CGFloat x = q.x, y = q.y, z = q.z, w = q.w;
 
-    m.m11 = 1 - 2*y*y - 2*z*z;
-    m.m12 = 2*x*y + 2*w*z;
-    m.m13 = 2*x*z - 2*w*y;
+    m.m11 = 1 - 2 * y * y - 2 * z * z;
+    m.m12 = 2 * x * y + 2 * w * z;
+    m.m13 = 2 * x * z - 2 * w * y;
     m.m14 = 0;
 
-    m.m21 = 2*x*y - 2*w*z;
-    m.m22 = 1 - 2*x*x - 2*z*z;
-    m.m23 = 2*y*z + 2*w*x;
+    m.m21 = 2 * x * y - 2 * w * z;
+    m.m22 = 1 - 2 * x * x - 2 * z * z;
+    m.m23 = 2 * y * z + 2 * w * x;
     m.m24 = 0;
 
-    m.m31 = 2*x*z + 2*w*y;
-    m.m32 = 2*y*z - 2*w*x;
-    m.m33 = 1 - 2*x*x - 2*y*y;
+    m.m31 = 2 * x * z + 2 * w * y;
+    m.m32 = 2 * y * z - 2 * w * x;
+    m.m33 = 1 - 2 * x * x - 2 * y * y;
     m.m34 = 0;
 
     m.m41 = 0;
@@ -83,104 +82,97 @@ static GSQuartzCoreQuaternion matrixToQuaternion(CATransform3D m)
 
     GSQuartzCoreQuaternion q;
 
-    if (m.m11 + m.m22 + m.m33 > 0)
-    {
+    if (m.m11 + m.m22 + m.m33 > 0) {
         CGFloat t = m.m11 + m.m22 + m.m33 + 1.;
-        CGFloat s = 0.5/sqrt(t);
+        CGFloat s = 0.5 / sqrt(t);
 
-        q.w = s*t;
-        q.z = (m.m12 - m.m21)*s;
-        q.y = (m.m31 - m.m13)*s;
-        q.x = (m.m23 - m.m32)*s;
+        q.w = s * t;
+        q.z = (m.m12 - m.m21) * s;
+        q.y = (m.m31 - m.m13) * s;
+        q.x = (m.m23 - m.m32) * s;
     }
-    else if (m.m11 > m.m22 && m.m11 > m.m33)
-    {
+    else if (m.m11 > m.m22 && m.m11 > m.m33) {
         CGFloat t = m.m11 - m.m22 - m.m33 + 1;
-        CGFloat s = 0.5/sqrt(t);
+        CGFloat s = 0.5 / sqrt(t);
 
-        q.x = s*t;
-        q.y = (m.m12 + m.m21)*s;
-        q.z = (m.m31 + m.m13)*s;
-        q.w = (m.m23 - m.m32)*s;
+        q.x = s * t;
+        q.y = (m.m12 + m.m21) * s;
+        q.z = (m.m31 + m.m13) * s;
+        q.w = (m.m23 - m.m32) * s;
     }
-    else if (m.m22 > m.m33)
-    {
-        CGFloat t = -m.m11 + m.m22 - m.m33 + 1;
-        CGFloat s = 0.5/sqrt(t);
+    else if (m.m22 > m.m33) {
+        CGFloat t = - m.m11 + m.m22 - m.m33 + 1;
+        CGFloat s = 0.5 / sqrt(t);
 
-        q.y = s*t;
-        q.x = (m.m12 + m.m21)*s;
-        q.w = (m.m31 - m.m13)*s;
-        q.z = (m.m23 + m.m32)*s;
+        q.y = s * t;
+        q.x = (m.m12 + m.m21) * s;
+        q.w = (m.m31 - m.m13) * s;
+        q.z = (m.m23 + m.m32) * s;
     }
-    else
-    {
-        CGFloat t = -m.m11 - m.m22 + m.m33 + 1;
-        CGFloat s = 0.5/sqrt(t);
+    else {
+        CGFloat t = - m.m11 - m.m22 + m.m33 + 1;
+        CGFloat s = 0.5 / sqrt(t);
 
-        q.z = s*t;
-        q.w = (m.m12 - m.m21)*s;
-        q.x = (m.m31 + m.m13)*s;
-        q.y = (m.m23 + m.m32)*s;
+        q.z = s * t;
+        q.w = (m.m12 - m.m21) * s;
+        q.x = (m.m31 + m.m13) * s;
+        q.y = (m.m23 + m.m32) * s;
     }
-    
+
     return q;
 }
 
 static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaternion a, GSQuartzCoreQuaternion b, CGFloat fraction)
 {
     // slerp
-	GSQuartzCoreQuaternion qr;
+    GSQuartzCoreQuaternion qr;
 
     /* reduction of calculations */
-    if (!memcmp(&a, &b, sizeof(a)))
-    {
+    if (! memcmp(&a, &b, sizeof(a))) {
         /* aside from making less calculations, this will also
          fix NaNs that would be returned if quaternions are equal */
         return a;
     }
-    if (fraction == 0.)
-    {
+    if (fraction == 0.) {
         return a;
     }
-    if (fraction == 1.)
-    {
+    if (fraction == 1.) {
         return b;
     }
 
     CGFloat dotproduct = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
-	CGFloat theta, st, sut, sout, coeff1, coeff2;
+    CGFloat theta, st, sut, sout, coeff1, coeff2;
 
-	theta = acos(dotproduct);
-    if (theta == 0.0)
-    {
+    theta = acos(dotproduct);
+    if (theta == 0.0) {
         /* shouldn't happen, since we already checked for equality of
          inbound quaternions */
         /* if we didn't make this check, we'd get a lot of NaNs. */
         return a;
     }
 
-	if (theta<0.0)
-        theta=-theta;
+    if (theta < 0.0) {
+        theta = - theta;
+    }
 
-	st = sin(theta);
-	sut = sin(fraction*theta);
-	sout = sin((1-fraction)*theta);
-	coeff1 = sout/st;
-	coeff2 = sut/st;
+    st = sin(theta);
+    sut = sin(fraction * theta);
+    sout = sin((1 - fraction) * theta);
+    coeff1 = sout / st;
+    coeff2 = sut / st;
 
-	qr.x = coeff1*a.x + coeff2*b.x;
-	qr.y = coeff1*a.y + coeff2*b.y;
-	qr.z = coeff1*a.z + coeff2*b.z;
-	qr.w = coeff1*a.w + coeff2*b.w;
+    qr.x = coeff1 * a.x + coeff2 * b.x;
+    qr.y = coeff1 * a.y + coeff2 * b.y;
+    qr.z = coeff1 * a.z + coeff2 * b.z;
+    qr.w = coeff1 * a.w + coeff2 * b.w;
 
     // normalize
-    CGFloat qrLen = sqrt(qr.x*qr.x + qr.y*qr.y + qr.z*qr.z + qr.w*qr.w);
+    CGFloat qrLen = sqrt(qr.x * qr.x + qr.y * qr.y + qr.z * qr.z + qr.w * qr.w);
     qr.x /= qrLen;
     qr.y /= qrLen;
     qr.z /= qrLen;
     qr.w /= qrLen;
-    
+
     return qr;
 }
 
@@ -213,7 +205,7 @@ CATransform3D interpolatedMatrixFromMatrix(CATransform3D fromTf, CATransform3D t
 
     /* translation */
     CGFloat fromTX = fromTf.m14, fromTY = fromTf.m24, fromTZ = fromTf.m34;
-    CGFloat   toTX =   toTf.m14,   toTY =   toTf.m24,   toTZ =   toTf.m34;
+    CGFloat toTX = toTf.m14, toTY = toTf.m24, toTZ = toTf.m34;
 
     CGFloat valueTX = linearInterpolation(fromTX, toTX, fraction);
     CGFloat valueTY = linearInterpolation(fromTY, toTY, fraction);
@@ -237,7 +229,7 @@ CATransform3D interpolatedMatrixFromMatrix(CATransform3D fromTf, CATransform3D t
 
 
 
-    
+
 
     /* rotation */
     CATransform3D fromRotation;
@@ -289,12 +281,12 @@ CATransform3D interpolatedMatrixFromMatrix(CATransform3D fromTf, CATransform3D t
     GSQuartzCoreQuaternion fromQuat = matrixToQuaternion(fromRotation);
     GSQuartzCoreQuaternion toQuat = matrixToQuaternion(toRotation);
 
-    CGFloat fromQuatLen = sqrt(fromQuat.x*fromQuat.x + fromQuat.y*fromQuat.y + fromQuat.z*fromQuat.z + fromQuat.w*fromQuat.w);
+    CGFloat fromQuatLen = sqrt(fromQuat.x * fromQuat.x + fromQuat.y * fromQuat.y + fromQuat.z * fromQuat.z + fromQuat.w * fromQuat.w);
     fromQuat.x /= fromQuatLen;
     fromQuat.y /= fromQuatLen;
     fromQuat.z /= fromQuatLen;
     fromQuat.w /= fromQuatLen;
-    CGFloat toQuatLen = sqrt(toQuat.x*toQuat.x + toQuat.y*toQuat.y + toQuat.z*toQuat.z + toQuat.w*toQuat.w);
+    CGFloat toQuatLen = sqrt(toQuat.x * toQuat.x + toQuat.y * toQuat.y + toQuat.z * toQuat.z + toQuat.w * toQuat.w);
     toQuat.x /= toQuatLen;
     toQuat.y /= toQuatLen;
     toQuat.z /= toQuatLen;
@@ -328,10 +320,9 @@ CATransform3D interpolatedMatrixFromMatrix(CATransform3D fromTf, CATransform3D t
     valueTf.m24 = valueTY;
     valueTf.m34 = valueTZ;
 
-    
-    
+
     valueTf = transpose(valueTf);
-    
+
     return valueTf;
 }
 

--- a/MTAnimation/UIView+MTAnimation.m
+++ b/MTAnimation/UIView+MTAnimation.m
@@ -195,7 +195,7 @@ static const char startUserInteractionEnabledKey;
                                                                       exaggeration:view.mt_animationExaggeration];
             [view addAnimation:keyframeAnimation
                          delay:delay
-                        forKey:@"bounds"
+                        forKey:@"boundsMT"
                          range:range
                        options:options
                    perspective:view.mt_animationPerspective];
@@ -216,7 +216,7 @@ static const char startUserInteractionEnabledKey;
                                                                        exaggeration:view.mt_animationExaggeration];
             [view addAnimation:keyframeAnimation
                          delay:delay
-                        forKey:@"position"
+                        forKey:@"positionMT"
                          range:range
                        options:options
                    perspective:view.mt_animationPerspective];
@@ -236,7 +236,7 @@ static const char startUserInteractionEnabledKey;
                                                                            exaggeration:view.mt_animationExaggeration];
             [view addAnimation:keyframeAnimation
                          delay:delay
-                        forKey:@"transform"
+                        forKey:@"transformMT"
                          range:range
                        options:options
                    perspective:view.mt_animationPerspective];
@@ -256,7 +256,7 @@ static const char startUserInteractionEnabledKey;
                                                                        exaggeration:view.mt_animationExaggeration];
             [view addAnimation:keyframeAnimation
                          delay:delay
-                        forKey:@"opacity"
+                        forKey:@"opacityMT"
                          range:range
                        options:options
                    perspective:view.mt_animationPerspective];
@@ -334,6 +334,9 @@ static const char startUserInteractionEnabledKey;
         progress += increment;
     }
 
+    // well, last value != final value, so we have to put the final value in
+    [values removeLastObject];
+    [values addObject:[NSValue mt_valueWithCGRect:toRect]];
     return values;
 }
 
@@ -361,6 +364,9 @@ static const char startUserInteractionEnabledKey;
         progress += increment;
     }
 
+    // well, last value != final value, so we have to put the final value in
+    [values removeLastObject];
+    [values addObject:[NSValue mt_valueWithCGPoint:toPoint]];
     return values;
 }
 
@@ -385,7 +391,10 @@ static const char startUserInteractionEnabledKey;
 
         progress += increment;
     }
-
+    
+    // well, last value != final value, so we have to put the final value in
+    [values removeLastObject];
+    [values addObject:[NSValue valueWithCATransform3D:toTransform]];
     return values;
 }
 
@@ -473,30 +482,30 @@ static const char startUserInteractionEnabledKey;
     void (^setFinalValueBlock)() = nil;
 
     // add the animation
-    if ([key isEqualToString:@"bounds"]) {
-        self.bounds             = self.startBounds;
+    if ([key isEqualToString:@"boundsMT"]) {
+        self.bounds = self.startBounds;
         [self.layer addAnimation:animation forKey:key];
         setFinalValueBlock = ^{
             self.layer.bounds = [[animation.values lastObject] MTRectValue];
         };
     }
-    else if ([key isEqualToString:@"position"]) {
-        self.center             = self.startCenter;
+    else if ([key isEqualToString:@"positionMT"]) {
+        self.center = self.startCenter;
         [self.layer addAnimation:animation forKey:key];
         setFinalValueBlock = ^{
             self.layer.position = [[animation.values lastObject] MTPointValue];
-            self.center         = self.layer.position;
+            self.center = self.layer.position;
         };
     }
-    else if ([key isEqualToString:@"opacity"]) {
-        self.mt_alpha           = self.startAlpha;
+    else if ([key isEqualToString:@"opacityMT"]) {
+        self.mt_alpha = self.startAlpha;
         [self.layer addAnimation:animation forKey:key];
         setFinalValueBlock = ^{
             self.layer.opacity = [[animation.values lastObject] floatValue];
         };
     }
-    else if ([key isEqualToString:@"transform"]) {
-        self.layer.transform    = self.startTransform3D;
+    else if ([key isEqualToString:@"transformMT"]) {
+        self.layer.transform = self.startTransform3D;
         [self.layer addAnimation:animation forKey:key];
         setFinalValueBlock = ^{
             self.layer.transform = [[animation.values lastObject] CATransform3DValue];


### PR DESCRIPTION
Three fixes here: 
1. Fixed final animation value for keyframe animations. Interpolation gives sometimes last value not equal to toValue
2. Fixed same as system animation key names ("bounds" -> "bounds_MT")
3. Fixed compilation for projects with objc-C++ specific stuff in PCH (only if user drag-n-drop files to his project)

P.S Sorry for some formatting changes
