### PR TITLE
Fix issue with completion of animation group on iOS 10

### DIFF
--- a/MTAnimation/UIView+MTAnimation.m
+++ b/MTAnimation/UIView+MTAnimation.m
@@ -770,6 +770,8 @@ static const char startUserInteractionEnabledKey;
 
 - (void)animationDidStart:(CAPropertyAnimation *)animation
 {
+    // We are interested only in animations that we create, and those must have the `keyPath` property: see
+    // `-[mt_animateWithViews:...]`. Others are ignored.
     if (![animation respondsToSelector:@selector(keyPath)]) {
         return;
     }

--- a/MTAnimation/UIView+MTAnimation.m
+++ b/MTAnimation/UIView+MTAnimation.m
@@ -770,6 +770,10 @@ static const char startUserInteractionEnabledKey;
 
 - (void)animationDidStart:(CAPropertyAnimation *)animation
 {
+    if (![animation respondsToSelector:@selector(keyPath)]) {
+        return;
+    }
+    
     dispatch_block_t setFinalValueBlock = self.animationCompletions[animation.keyPath];
     if (setFinalValueBlock) {
         setFinalValueBlock();


### PR DESCRIPTION
Our crash analytics showed that on iOS 10 our app is crashing because the completion method of `UIView+MTAnimation` `animationDidStart:` is called with argument of type `CAAnimationGroup` which does not seem to have the `keyPath` property, which seems logical. 

Solution is to guard the actions that require `keyPath` to animations that support it.
